### PR TITLE
Return path inside recursive trace function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,13 +43,33 @@ Example
 
    >>> from trace_dkey import trace
    >>> l={'a':{'b':{'c':{'d':{'e':{'f':1}}}}}}
-   >>> trace(l,'f')
-   Found 'f' at  a--> b--> c--> d--> e-->f
+   >>> print(trace(l,'f'))
+   [['a', 'b', 'c', 'd', 'e', 'f']]
 
    Now you can query it as l['a']['b']['c']['d']['e']['f']
 
    >>> l['a']['b']['c']['d']['e']['f']
    1
+
+General Info
+============
+
+The value returned by the `trace` function is an array of paths, where each path is an array of dictionary keys.
+Because of that, the library can be used in a practical way by taking advantage of this format.
+In the example below we use the returned path to iterate over the dictionary keys and print the key value:
+
+.. code:: py
+
+   from trace_dkey import trace
+   l={'a':{'b':{'c':{'d':{'e':{'f':1}}}}}}
+
+   paths = trace(l,'f')
+
+   for path in paths:
+      dic = l
+      for key in path:
+         dic = dic[key]
+      print(dic)
 
 Contributing
 ============

--- a/README.rst
+++ b/README.rst
@@ -54,9 +54,9 @@ Example
 General Info
 ============
 
-The value returned by the `trace` function is an array of paths, where each path is an array of dictionary keys.
-Because of that, the library can be used in a practical way by taking advantage of this format.
-In the example below we use the returned path to iterate over the dictionary keys and print the key value:
+| The value returned by the `trace` function is an array of paths, where each path is an array of dictionary keys.
+| Because of that, the library can be used in a practical way by taking advantage of this format.
+| In the example below we use the returned path to iterate over the dictionary keys and print the key value:
 
 .. code:: py
 

--- a/src/trace_dkey/__init__.py
+++ b/src/trace_dkey/__init__.py
@@ -1,7 +1,7 @@
 import _ast
 import ast
 import copy
-from typing import Tuple, List, Any, Dict
+from typing import Tuple, List, Any, Dict, Union
 
 
 def __process_tuple(tuple_elts: List) -> Tuple:
@@ -10,7 +10,7 @@ def __process_tuple(tuple_elts: List) -> Tuple:
         ans.append(elt.value)
     return tuple(ans)
 
-def __trace_key(dict_key: Any, dict_value: Any, key, path = []) -> None:
+def __trace_key(dict_key: Any, dict_value: Any, key: Any, path: List[Union[str, Tuple]] = []) -> None:
     # path stores the path to the current dict position
     path = copy.deepcopy(path)
     # paths stores all the paths found inside this dict position

--- a/tests/test_trace_dkey.py
+++ b/tests/test_trace_dkey.py
@@ -8,29 +8,28 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 from trace_dkey import trace 
 
-def get_stdout_of_trace(l,p):
-    f = io.StringIO()
-    with redirect_stdout(f):
-        trace(l,p)
-    return f.getvalue()
-
 
 @pytest.fixture
 def test_trace_fixture():
     dict1 = {'a': {'b': {'c': {'d': {'e': {'f': 1}}}}}}
-    fixture1 = get_stdout_of_trace(dict1,'f')
+    fixture1 = trace(dict1, 'f')
     dict2 = {'a': {'b': {'c': {'d': {'e': {('h','i'): ('h', 'i')}, 'g': 1}}}}}
-    fixture2 = get_stdout_of_trace(dict2,('h','i'))
+    fixture2 = trace(dict2, ('h','i'))
     dict3 = {'a': {'b':{'c':{('d','e'):1}}}}
-    fixture3 = get_stdout_of_trace(dict2,'r')
-    return fixture1, fixture2, fixture3
+    fixture3 = trace(dict3, 'r')
+    dict4 = {'a': {'b': {'c': {('d','e'): 1}}, 'c': 1}}
+    fixture4 = trace(dict4, 'c')
+    return fixture1, fixture2, fixture3, fixture4
 
 
 def test_when_key_is_string(test_trace_fixture):
-    assert test_trace_fixture[0][:-1] == f"Found 'f' at  a--> b--> c--> d--> e-->f"
+    assert test_trace_fixture[0] == [['a', 'b', 'c', 'd', 'e', 'f']]
 
 def test_when_key_is_tuple(test_trace_fixture):
-    assert test_trace_fixture[1][:-1] == f"Found '('h', 'i')' at  a--> b--> c--> d--> e-->('h', 'i')"
+    assert test_trace_fixture[1] == [['a', 'b', 'c', 'd', 'e', ('h', 'i')]]
 
 def test_when_key_is_not_present(test_trace_fixture):
-    assert test_trace_fixture[2][:-1] == ''
+    assert test_trace_fixture[2] == []
+
+def test_when_multiple_keys_found(test_trace_fixture):
+    assert test_trace_fixture[3] == [['a', 'b', 'c'], ['a', 'c']]

--- a/tests/test_trace_dkey.py
+++ b/tests/test_trace_dkey.py
@@ -1,5 +1,3 @@
-from contextlib import redirect_stdout
-import io
 import os
 import sys
 


### PR DESCRIPTION
Related to: #1 

The `__trace_key` function was updated to return the found paths instead of printing.
Now it uses an array of paths that gets updated every time the key is found.

I'm storing each path as an array of dictionary keys so we could do something like: https://stackoverflow.com/a/14692747/16586258

