### PR TITLE
Added Python version 3.14 and removed support for Python version 3.9

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10","3.11","3.12","3.13"]
+        python-version: ["3.10","3.11","3.12","3.13","3.14"]
         os: [ubuntu-20.04, macOS-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,13 @@ setup(
         "tracer","dict-key-path-finder"
     ],
     install_requires=["click"],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     classifiers=[
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Operating System :: OS Independent",
     ],
     include_package_data=True,


### PR DESCRIPTION
This PR has minor configuration changes for enabling Python 3.14 version and dropping version 3.9.
Issue #19

## Testing 

- Validated all test cases for python 3.14 version
- Verified installation of `trace-dkey` on python 3.9 version. Installation fails as expected.
- Manually tested trace function.